### PR TITLE
Toggle comments

### DIFF
--- a/.cr_config
+++ b/.cr_config
@@ -1,1 +1,1 @@
-{"read_line_numbers": false, "read_comments": false}
+{"read_line_numbers": false, "read_comments": true}

--- a/config.py
+++ b/config.py
@@ -8,10 +8,10 @@ import sublime_plugin
 class Config:
     '''Config class to serve as a container and obejct for CodeReader
     configurations
-    Formatted as a json file, but loaded as a dictioanry in memory'''
+    Formatted as a json file, but loaded as a dictionary in memory'''
     is_initialized = False
     DEFAULT_CONFIG = {
-        'read_comments': False,
+        'read_comments': True,
         'read_line_numbers': False,
 
     }

--- a/developer_notes.txt
+++ b/developer_notes.txt
@@ -4,3 +4,5 @@ This project does not support:
 	* templates
 	* nice do-while loop formating
 	* closing brackets on the same line as opening brackets
+
+To toggle comments and/or line numbers, the key binding must be run before starting CodeReader.py

--- a/scopes.py
+++ b/scopes.py
@@ -16,7 +16,7 @@ symbol_list = {r'cout': 'see out', r'endl': 'endline',
                r'*=': ' times equals ', r'/=': ' divide equals ',
                r'<<': ',', r'>>': ',', r';': ',',
                r'<=': ' less than or equal to ',
-               r'//': 'comment: ', r'/*': 'comment:', r'*/': 'end comment',
+               r'//': 'comment: ', r'/*': 'comment:', r'*/': 'end comment:',
                r'>=': ' greater than or equal to ',
                r'*': ' star ', r'&': ' ampersand ', r'(': ' ', r')': ' ',
                r'|': ' bar ', r'<': ' less than ', r'>': ' greater than '}
@@ -155,7 +155,15 @@ class Function(Scope):
                     single_line_comment = True
 
                 parsed_string = parse_symbols(line_str)
-                panel_options.append(parsed_string)
+
+                # Check if comment reading is off
+                # If it is, skip appending the comment to the list
+                if 'comment:' in parsed_string and not Config().get(read_comment):
+                    print("found comment and skipping")
+                    continue
+
+                else:
+                    panel_options.append(parsed_string)
 
                 # Check for single line comment
                 if single_line_comment:


### PR DESCRIPTION
Addresses toggling comments to be read on or off by integrating Config.py with Scopes.py. Currently only works for comments inside of functions. I'll leave within classes for the omega release. Comments being read is defaulted to True.