### PR TITLE
Reading comments and line numbers in classes. "Exiting scope <blah>."

### DIFF
--- a/.cr_config
+++ b/.cr_config
@@ -1,1 +1,1 @@
-{"read_line_numbers": true, "read_comments": true}
+{"read_comments": true, "read_line_numbers": true}


### PR DESCRIPTION
Addresses issues #66, #62, and #61 !
Comments, exiting scope “Blah”, and line numbers will now be read if they are inside classes.
Made a function to do this. Might not be the most elegant solution because I’m passing a lot of parameters down to it but it works?